### PR TITLE
Remove support to apply default HTML escape characters strategy.

### DIFF
--- a/src/main/java/org/mrcsparker/ceeql/CeeqlTemplate.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlTemplate.java
@@ -2,6 +2,7 @@ package org.mrcsparker.ceeql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +29,13 @@ class CeeqlTemplate {
         }
 
         try {
-            Handlebars handlebars = new Handlebars();
+
+            // We are not escaping the string sequence at this step. By default Handlebars escape a string
+            // sequence using an HTML strategy for characters ( < > " \' ` &). This step is replacing
+            // valid SQL statements characters with their escaped counter part causing queries to fail.
+            // The next step after Handlebars preprocessing is to execute the SQL statement which will be
+            // appropriately escaped because JDBI uses binding of values to avoid any SQL injection attacks.
+            Handlebars handlebars = new Handlebars().with((final CharSequence value) -> value.toString());
             handlebars.registerHelper("safe", new SafeHelper());
             com.github.jknack.handlebars.Template template = handlebars.compileInline(s);
 

--- a/src/test/java/org/mrcsparker/ceeql/CeeqlTemplateTest.java
+++ b/src/test/java/org/mrcsparker/ceeql/CeeqlTemplateTest.java
@@ -73,4 +73,27 @@ public class CeeqlTemplateTest {
 
         ceeql.close();
     }
+
+    @Test
+    public void should_not_escape_characters_with_default_strategy_template() {
+        Ceeql ceeql = DbCreator.create();
+
+        String sql = new StringBuilder()
+                .append("SELECT {{#each data_list.formula_list}}\n")
+                .append("{{safe this}}{{#unless @last}},{{/unless}}\n")
+                .append("{{/each}}\n")
+                .append("FROM products\n")
+                .toString();
+
+        HashMap<String, String> args = new HashMap<>();
+        args.put("data_list", "{\"formula_list\": [ \"price\", \"vendor_id\", \"name\", \"price > 150\" ] }");
+
+        String output = ceeql.select(sql, args);
+        System.out.println(output);
+        assertEquals(output,
+                "[{\"price > 150\":false,\"price\":100.0000,\"vendor_id\":1,\"name\":\"first\"},{\"price > 150\":true,\"price\":200.0000,\"vendor_id\":2,\"name\":\"second\"},{\"price > 150\":true,\"price\":300.0000,\"vendor_id\":3,\"name\":\"third\"}]");
+
+        ceeql.close();
+    }
 }
+


### PR DESCRIPTION
Hi Chris, 

We have an issue when building dinamic SQL queries  where parameter can have values making use of grater than( > ) and less than (<) symbols an being escape for HandleBars. In the context of SQL statements where we are using Handlebars I don't see why to user the default HTML Handlebars escaping strategy. Please look at the test and the code overwriting of the EscapeStrategy object. Please let me know your thoughts. 