### PR TITLE
Refactor CeeqlTemplate.apply to propagate handlebars exceptions; This…

### DIFF
--- a/src/main/java/org/mrcsparker/ceeql/CeeqlAction.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlAction.java
@@ -2,6 +2,7 @@ package org.mrcsparker.ceeql;
 
 import org.skife.jdbi.v2.Handle;
 
+import java.io.IOException;
 import java.util.Map;
 
 abstract class CeeqlAction {
@@ -9,7 +10,7 @@ abstract class CeeqlAction {
     protected final Map<String, String> args;
     protected final org.skife.jdbi.v2.Update update;
 
-    public CeeqlAction(Handle dbiHandle, String sql, Map<String, String> args) {
+    public CeeqlAction(Handle dbiHandle, String sql, Map<String, String> args) throws IOException {
         this.args = args;
         this.update = CeeqlQuery.create(dbiHandle, CeeqlTemplate.apply(sql, args), args);
     }

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlBatch.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlBatch.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.skife.jdbi.v2.Batch;
 import org.skife.jdbi.v2.Handle;
 
+import java.io.IOException;
 import java.util.Map;
 
 class CeeqlBatch {
@@ -21,7 +22,7 @@ class CeeqlBatch {
         this.args = args;
     }
 
-    public String exec() {
+    public String exec() throws IOException {
         Batch batch = dbiHandle.createBatch();
         batch.add(CeeqlTemplate.apply(sql, args));
 

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlDelete.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlDelete.java
@@ -1,10 +1,12 @@
 package org.mrcsparker.ceeql;
 
 import org.skife.jdbi.v2.Handle;
+
+import java.io.IOException;
 import java.util.Map;
 
 class CeeqlDelete extends CeeqlAction {
-    public CeeqlDelete(Handle dbiHandle, String sql, Map<String, String> args) {
+    public CeeqlDelete(Handle dbiHandle, String sql, Map<String, String> args) throws IOException {
         super(dbiHandle, sql, args);
     }
 

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlInsert.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlInsert.java
@@ -1,10 +1,12 @@
 package org.mrcsparker.ceeql;
 
 import org.skife.jdbi.v2.Handle;
+
+import java.io.IOException;
 import java.util.Map;
 
 class CeeqlInsert extends CeeqlAction {
-    public CeeqlInsert(Handle dbiHandle, String sql, Map<String, String> args) {
+    public CeeqlInsert(Handle dbiHandle, String sql, Map<String, String> args) throws IOException {
         super(dbiHandle, sql, args);
     }
 }

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlSelect.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlSelect.java
@@ -2,6 +2,7 @@ package org.mrcsparker.ceeql;
 
 import org.skife.jdbi.v2.Handle;
 
+import java.io.IOException;
 import java.util.Map;
 
 class CeeqlSelect {
@@ -9,7 +10,7 @@ class CeeqlSelect {
     private final org.skife.jdbi.v2.Query query;
     private final Map<String, String> args;
 
-    public CeeqlSelect(Handle dbiHandle, String sql, Map<String, String> args) {
+    public CeeqlSelect(Handle dbiHandle, String sql, Map<String, String> args) throws IOException {
         this.query = CeeqlQuery.build(dbiHandle, CeeqlTemplate.apply(sql, args), args);
         this.args = args;
     }

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlTemplate.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlTemplate.java
@@ -2,20 +2,16 @@ package org.mrcsparker.ceeql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.mrcsparker.ceeql.handlbars.SafeHelper;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 class CeeqlTemplate {
 
-    private final static Logger log = LogManager.getLogger(CeeqlTemplate.class);
-
-    public static String apply(String s, Map<String, String> args) {
+    public static String apply(String s, Map<String, String> args) throws IOException {
 
         ObjectReader mapper = new ObjectMapper().readerFor(Object.class);
 
@@ -28,21 +24,15 @@ class CeeqlTemplate {
             }
         }
 
-        try {
+        // We are not escaping the string sequence at this step. By default Handlebars escape a string
+        // sequence using an HTML strategy for characters ( < > " \' ` &). This step is replacing
+        // valid SQL statements characters with their escaped counter part causing queries to fail.
+        // The next step after Handlebars preprocessing is to execute the SQL statement which will be
+        // appropriately escaped because JDBI uses binding of values to avoid any SQL injection attacks.
+        Handlebars handlebars = new Handlebars().with((final CharSequence value) -> value.toString());
+        handlebars.registerHelper("safe", new SafeHelper());
+        com.github.jknack.handlebars.Template template = handlebars.compileInline(s);
 
-            // We are not escaping the string sequence at this step. By default Handlebars escape a string
-            // sequence using an HTML strategy for characters ( < > " \' ` &). This step is replacing
-            // valid SQL statements characters with their escaped counter part causing queries to fail.
-            // The next step after Handlebars preprocessing is to execute the SQL statement which will be
-            // appropriately escaped because JDBI uses binding of values to avoid any SQL injection attacks.
-            Handlebars handlebars = new Handlebars().with((final CharSequence value) -> value.toString());
-            handlebars.registerHelper("safe", new SafeHelper());
-            com.github.jknack.handlebars.Template template = handlebars.compileInline(s);
-
-            return template.apply(parsedArgs);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "";
-        }
+        return template.apply(parsedArgs);
     }
 }

--- a/src/main/java/org/mrcsparker/ceeql/CeeqlUpdate.java
+++ b/src/main/java/org/mrcsparker/ceeql/CeeqlUpdate.java
@@ -2,10 +2,11 @@ package org.mrcsparker.ceeql;
 
 import org.skife.jdbi.v2.Handle;
 
+import java.io.IOException;
 import java.util.Map;
 
 class CeeqlUpdate extends CeeqlAction {
-    public CeeqlUpdate(Handle dbiHandle, String sql, Map<String, String> args) {
+    public CeeqlUpdate(Handle dbiHandle, String sql, Map<String, String> args) throws IOException {
         super(dbiHandle, sql, args);
     }
 }

--- a/src/test/java/org/mrcsparker/ceeql/CeeqlSelectCeeqlJsonTest.java
+++ b/src/test/java/org/mrcsparker/ceeql/CeeqlSelectCeeqlJsonTest.java
@@ -6,6 +6,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static org.hamcrest.core.StringContains.containsString;
 
 public class CeeqlSelectCeeqlJsonTest {
     @Test
@@ -53,6 +56,23 @@ public class CeeqlSelectCeeqlJsonTest {
 
         assertEquals(output,
                 "[{\"price\":100.0000,\"vendor_id\":1,\"name\":\"first\",\"id\":1},{\"price\":200.0000,\"vendor_id\":2,\"name\":\"second\",\"id\":2}]");
+
+        p.close();
+    }
+
+    @Test
+    public void should_return_json_error_message_when_handlebars_query_syntax_cannot_be_parsed() {
+        Ceeql p = DbCreator.create();
+
+        String sql = "select {{#if cols}}{{#each cols}} MIN({{safe this}}) as min_{{safe this}},MAX({{safe this}}) as max_{{safe this}} from {{tablename}};";
+        Map<String, String> args = new HashMap<>();
+        args.put("vendorId1", "1");
+        args.put("vendorId2", "2");
+
+        String output = p.select(sql, args);
+
+        assertThat(output, containsString("[{\"messageType\":\"error\",\"messageSubType\":\"HandlebarsException\",\"timestamp\":"));
+        assertThat(output, containsString(sql));
 
         p.close();
     }


### PR DESCRIPTION
… make the error handling logic more robust, instead of just sending back an empty string which was creating side effects at runtime when using invalid query object. No query binding or query execution is perform at the sql level until handlebars syntax is fixed.